### PR TITLE
EXT-1372: Enable Tree Shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyblok/mui",
   "description": "A Storyblok MUI theme with reusable components.",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": {
     "name": "Johannes Lindgren",
     "email": "johannes.lindgren@storyblok.com"

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   },
   "sideEffects": false,
   "type": "module",
-  "module": "dist/mui.js",
+  "module": "dist/src/index.js",
   "main": "dist/mui.umd.cjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/mui.js",
+      "import": "./dist/src/index.js",
       "require": "./dist/mui.umd.cjs"
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
       name: 'storyblokMui',
     },
     rollupOptions: {
-      external: ['react', 'react-proptypes', 'react-dom', '@mui/material'],
+      external: ['react', 'react-proptypes', 'react-dom', '@mui/material', '@mui/system'],
+      output: {
+        // preserveModules: true,
+      },
     },
     emptyOutDir: false,
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,10 +17,22 @@ export default defineConfig({
       name: 'storyblokMui',
     },
     rollupOptions: {
-      external: ['react', 'react-proptypes', 'react-dom', '@mui/material', '@mui/system'],
-      output: {
-        // preserveModules: true,
-      },
+      external: [
+        'react',
+        'react-proptypes',
+        'react-dom',
+        '@mui/material',
+        '@mui/system',
+      ],
+      output: [
+        {
+          format: 'cjs',
+        },
+        {
+          preserveModules: true,
+          format: 'es',
+        },
+      ],
     },
     emptyOutDir: false,
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
     lib: {
       // Could also be a dictionary or array of multiple entry points
       entry: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
-      name: 'storyblokMui',
     },
     rollupOptions: {
       external: [
@@ -23,14 +22,19 @@ export default defineConfig({
         'react-dom',
         '@mui/material',
         '@mui/system',
+        '@emotion/styled',
+        '@emotion/react',
       ],
       output: [
         {
-          format: 'cjs',
+          format: 'umd',
+          name: 'mui',
         },
         {
           preserveModules: true,
           format: 'es',
+          dir: 'dist',
+          entryFileNames: '[name].js',
         },
       ],
     },


### PR DESCRIPTION
Enable tree shaking for `@storyblok/mui`. Rollup would already eliminate dead code from `dist/`, so the total bundle size would be quite small. However, library consumers that only used a few components from the library would have to include the entire bundle.

Tree shaking is enabled vua the rollup options `output.preserveModules`. This will produce a tree of folders and files rather than a single esm file. This only affects the es output. 

## Why

Since its inception, the MUI component library has grown in size. Inadequate tree shaking hasn't been a huge issue for apps, as the relative added size from this library is quite small. However, it is more important that field plugins are small, because the visual editor may load multiple field plugin app at the same time.

## How to test

Build the library

```shell
yarn build
```

Then build an app and a field plugin using both the old version of the library and the new one.

### Build Without tree-shaking

Open an app and a field plugin, such as

- Deployments App
- Bynder Field Plugin (check out the branch )

Build the apps

```shell
yarn build
```

Note the bundle sizes.

For the deployments app:

<img width="574" alt="image" src="https://user-images.githubusercontent.com/14206504/231457785-7fd85023-d80b-4f76-8449-f31fb3c807d4.png">

For the Bynder field plugin:

<img width="364" alt="image" src="https://user-images.githubusercontent.com/14206504/231457832-24a88a4e-ffed-4e93-96bb-c47276268fe9.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/14206504/231457871-85c2b1cf-0248-4755-b31d-bd066a40e901.png">

### Build With tree-shaking

Link the library

```shell
yarn link @storyblok/mui
```

For nextjs app, ensure that you configure webpack to resolve linked packages:

next.config.js:

```javascript
webpack: (config, { dev }) => {
    // eslint-disable-next-line functional/immutable-data
    Object.assign(config.resolve.alias, {
      next: path.resolve('./node_modules/next'),
      react: path.resolve('./node_modules/react'),
      'react-dom': path.resolve('./node_modules/react-dom'),
      '@mui': path.resolve('./node_modules/@mui'),
      '@storyblok/mui': path.resolve('./node_modules/@storyblok/mui'),
      '@emotion': path.resolve('./node_modules/@emotion'),
    })
    // Important: return the modified config
    return config
  },
```

Build the apps

```shell
yarn build
```

Note the bundle sizes.

For the deployments app:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/14206504/231457728-af58b947-ac2b-4f64-9d33-e82c55746ec1.png">

For the Bynder field plugin:

<img width="391" alt="image" src="https://user-images.githubusercontent.com/14206504/231457681-e7e1ab64-f592-4921-9e9a-a30861e2f996.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/14206504/231457493-786efeca-33b4-4573-b2ba-ed26087a305a.png">
