### PR TITLE
EXT-1400: Removing Gradient From Storybook DemoIcon

### DIFF
--- a/src/storybook/demo-utils/DemoIcon.tsx
+++ b/src/storybook/demo-utils/DemoIcon.tsx
@@ -3,13 +3,7 @@ import { StoryblokIcon } from '@src/icons'
 import { IconBox } from '@src/components/IconBox/IconBox'
 
 export const DemoIcon: FunctionComponent = () => (
-  <IconBox
-    color="primary"
-    sx={{
-      background: ({ palette }) =>
-        `linear-gradient(0deg, ${palette.primary.dark} 0%, ${palette.primary.main} 100%)`,
-    }}
-  >
-    <StoryblokIcon />
+  <IconBox color="primary">
+    <StoryblokIcon fontSize="inherit" />
   </IconBox>
 )


### PR DESCRIPTION
Removes the Gradient from the DemoIcon component, which is not exported by the library, but used in the Storybook: https://storyblok-mui.vercel.app/?path=/story/layout-appheader--basic

From:
<img width="924" alt="image" src="https://user-images.githubusercontent.com/14206504/232487708-9ebf4c93-90de-4af6-a3bf-cf7d51c12b5f.png">

To:
<img width="924" alt="image" src="https://user-images.githubusercontent.com/14206504/232487741-777db485-2a36-4db1-bfb0-baf54cbef516.png">
