### PR TITLE
Improved Colors for Buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storyblok/mui",
   "description": "A Storyblok MUI theme with reusable components.",
-  "version": "0.0.22",
+  "version": "0.1.0",
   "author": {
     "name": "Johannes Lindgren",
     "email": "johannes.lindgren@storyblok.com"

--- a/src/storybook/mui-components/Button.stories.tsx
+++ b/src/storybook/mui-components/Button.stories.tsx
@@ -64,16 +64,69 @@ EndIcon.args = {
   endIcon: <StoryblokIcon />,
 }
 
-export const Text = Template.bind({})
-Text.args = {
-  variant: 'text',
+export const ContainedPrimary = Template.bind({})
+ContainedPrimary.args = {
+  variant: 'contained',
+  color: 'primary',
   children: 'Button',
   endIcon: <StoryblokIcon />,
 }
 
-export const Outlined = Template.bind({})
-Outlined.args = {
+export const ContainedSecondary = Template.bind({})
+ContainedSecondary.args = {
+  variant: 'contained',
+  color: 'secondary',
+  children: 'Button',
+  endIcon: <StoryblokIcon />,
+}
+
+export const ContainedInherit = Template.bind({})
+ContainedInherit.args = {
+  variant: 'contained',
+  color: 'inherit',
+  children: 'Button',
+  endIcon: <StoryblokIcon />,
+}
+
+export const OutlinedPrimary = Template.bind({})
+OutlinedPrimary.args = {
   variant: 'outlined',
+  color: 'primary',
+  children: 'Button',
+  endIcon: <StoryblokIcon />,
+}
+export const OutlinedSecondary = Template.bind({})
+OutlinedSecondary.args = {
+  variant: 'outlined',
+  color: 'secondary',
+  children: 'Button',
+  endIcon: <StoryblokIcon />,
+}
+export const OutlinedInherit = Template.bind({})
+OutlinedInherit.args = {
+  variant: 'outlined',
+  color: 'inherit',
+  children: 'Button',
+  endIcon: <StoryblokIcon />,
+}
+
+export const TextPrimary = Template.bind({})
+TextPrimary.args = {
+  variant: 'text',
+  color: 'primary',
+  children: 'Button',
+  endIcon: <StoryblokIcon />,
+}
+export const TextSecondary = Template.bind({})
+TextSecondary.args = {
+  variant: 'text',
+  color: 'secondary',
+  children: 'Button',
+  endIcon: <StoryblokIcon />,
+}
+export const TextInherit = Template.bind({})
+TextInherit.args = {
+  variant: 'text',
   color: 'inherit',
   children: 'Button',
   endIcon: <StoryblokIcon />,

--- a/src/storybook/mui-components/IconButton.stories.tsx
+++ b/src/storybook/mui-components/IconButton.stories.tsx
@@ -32,7 +32,20 @@ const Template: ComponentStory<typeof Component> = (args) => (
   <Component {...args} />
 )
 
-export const Icon_Button = Template.bind({})
-Icon_Button.args = {
+export const Default = Template.bind({})
+Default.args = {
+  color: 'default',
+  children: <ArrowForwardIcon />,
+}
+
+export const Primary = Template.bind({})
+Primary.args = {
+  color: 'primary',
+  children: <ArrowForwardIcon />,
+}
+
+export const Secondary = Template.bind({})
+Secondary.args = {
+  color: 'secondary',
   children: <ArrowForwardIcon />,
 }

--- a/src/theme/light-theme.tsx
+++ b/src/theme/light-theme.tsx
@@ -399,12 +399,20 @@ const lightTheme = createTheme({
           fontSize: font_16,
           padding: `20px 43px`,
         },
+        containedInherit: {
+          backgroundColor: light_25,
+        },
         outlinedInherit: {
           borderColor: palette.divider,
         },
         outlinedSecondary: {
           borderColor: palette.divider,
         },
+      },
+    },
+    MuiIconButton: {
+      defaultProps: {
+        color: 'secondary',
       },
     },
     MuiFab: {


### PR DESCRIPTION
Stylistic changes to buttons:

- `Button` with `variant=contained` and `color=inherit`, the background colors was changed.
- For IconButton, the default color prop was set to 'secondary'.
- Added stories for `Button` and `IconButton`.

## Why

To match Storyblok's design system.

## How to Test

Preview:  https://mui-3lxsuzjlv-storyblok-com.vercel.app/?path=/story/mui-components-button--contained-inherit
