### PR TITLE
EXT-1489: Styles for code and pre

### DIFF
--- a/src/storybook/primitives/code.stories.tsx
+++ b/src/storybook/primitives/code.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+
+import { Alert, Box } from '@mui/material'
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: `HTML Elements/code`,
+  component: Box,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {
+    severity: {
+      control: 'select',
+      options: ['success', 'info', 'warning', 'error'],
+    },
+  },
+  // decorators: [(Story) => (
+  //     <ThemeProvider theme={lightTheme}>
+  //       <Story />
+  //     </ThemeProvider>
+  // )]
+} as ComponentMeta<typeof Box>
+
+const exampleInlineCode = `console.log("Hello, Storyblok")`
+
+const Template: ComponentStory<typeof Box> = () => (
+  <code>{exampleInlineCode}</code>
+)
+
+const BackgroundTemplate: ComponentStory<typeof Box> = () => (
+  <Alert severity="info">
+    <code>{exampleInlineCode}</code>
+  </Alert>
+)
+
+export const InlineCode = Template.bind({})
+InlineCode.args = {}
+
+export const OnBackground = BackgroundTemplate.bind({})
+OnBackground.args = {}

--- a/src/storybook/primitives/pre.stories.tsx
+++ b/src/storybook/primitives/pre.stories.tsx
@@ -1,0 +1,67 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+
+import { Box } from '@mui/material'
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: `HTML Elements/pre`,
+  component: Box,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {
+    severity: {
+      control: 'select',
+      options: ['success', 'info', 'warning', 'error'],
+    },
+  },
+  // decorators: [(Story) => (
+  //     <ThemeProvider theme={lightTheme}>
+  //       <Story />
+  //     </ThemeProvider>
+  // )]
+} as ComponentMeta<typeof Box>
+
+const exampleCodeBlock = `const printHello = () => {
+  console.log("Hello, Storyblok")
+}`
+const exampleCodeBlockOverflow = `const printHello = () => {
+  console.log("Hello, Storyblok")
+  console.log("A very very very very very very very very very very  very  very  very  very  very  very  very  very  very long message.")
+}`
+
+const CodeBlockTemplate: ComponentStory<typeof Box> = (args) => (
+  <Box
+    component="pre"
+    {...args}
+  >
+    <code>{exampleCodeBlock}</code>
+  </Box>
+)
+const CodeBlockTemplateOverflow: ComponentStory<typeof Box> = (args) => (
+  <Box
+    component="pre"
+    {...args}
+  >
+    <code>{exampleCodeBlockOverflow}</code>
+  </Box>
+)
+
+const codeBlockSxProp = {
+  bgcolor: 'secondary.main',
+  color: 'secondary.contrastText',
+  p: 3,
+  borderRadius: 2,
+  overflowX: 'auto',
+} as const
+
+export const Basic = CodeBlockTemplate.bind({})
+Basic.args = {}
+
+export const DarkCodeBlock = CodeBlockTemplate.bind({})
+DarkCodeBlock.args = {
+  sx: codeBlockSxProp,
+}
+
+export const Overflow = CodeBlockTemplateOverflow.bind({})
+Overflow.args = {
+  sx: codeBlockSxProp,
+}

--- a/src/theme/light-theme.tsx
+++ b/src/theme/light-theme.tsx
@@ -268,13 +268,15 @@ const lightTheme = createTheme({
   components: {
     MuiCssBaseline: {
       styleOverrides: {
-        code: {
+        '&:not(pre)>code': {
           fontFamily: `ui-monospace,Menlo,Monaco,"Roboto Mono","Oxygen Mono","Ubuntu Monospace","Source Code Pro","Droid Sans Mono","Courier New",monospace`,
           color: sb_dark_blue,
           backgroundColor: palette.grey['50'],
           borderRadius: shape.borderRadius,
           padding: '3px 5px',
-          fontSize: font_13,
+        },
+        pre: {
+          margin: 0,
         },
         mark: {
           backgroundColor: palette.action.selected,


### PR DESCRIPTION
## What

Improved style for code and pre element. Added examples to Storybook for how to style a code block.

![image](https://user-images.githubusercontent.com/14206504/234901378-b6492474-9346-47f8-bb80-c332b8d8668d.png)
![image](https://user-images.githubusercontent.com/14206504/234901446-b5a63d19-a686-43ab-abe9-0ca3dd5e1c70.png)


## Why

Useful in the Sandbox app. 

Useful for the community.

## How to test

Open the preview of the Storybook, then open the stories for `code` and `pre`.

![image](https://user-images.githubusercontent.com/14206504/234901288-33e7543b-561a-440f-ac7f-c092192711d4.png)
